### PR TITLE
Better sshconfig parsing

### DIFF
--- a/lua/netman/providers/ssh.lua
+++ b/lua/netman/providers/ssh.lua
@@ -115,14 +115,14 @@ function SSH:new(auth_details, provider_cache)
         return provider_cache:get_item(cache_key)
     end
     local _ssh = {}
+    local ssh_config = require("netman.api").internal.get_config('netman.providers.ssh'):get('hosts')[auth_details.host]
     _ssh.protocol = 'ssh'
     _ssh._auth_details = auth_details
     _ssh.host = _ssh._auth_details.host
-    _ssh.pass = _ssh._auth_details.password or ''
-    _ssh.user = _ssh._auth_details.user or ''
-    _ssh.port = _ssh._auth_details.port or ''
-    _ssh.key  = _ssh._auth_details.key or ''
-    _ssh.__type = 'netman_provider_ssh'
+    _ssh.pass = _ssh._auth_details.password or ssh_config.password or ''
+    _ssh.user = _ssh._auth_details.user or ssh_config.user or ''
+    _ssh.port = _ssh._auth_details.port or ssh_config.port or ''
+    _ssh.key  = _ssh._auth_details.key or ssh_config.identityfile or ''    _ssh.__type = 'netman_provider_ssh'
     _ssh.cache = CACHE:new(CACHE.FOREVER)
 
     _ssh.console_command = { 'ssh' }
@@ -141,6 +141,14 @@ function SSH:new(auth_details, provider_cache)
         table.insert(_ssh._put_command, '-i')
         table.insert(_ssh.console_command, _ssh.key)
         table.insert(_ssh._put_command, _ssh.key)
+    end
+    if ssh_config.proxyjump then
+        table.insert(_ssh.console_command, '-J')
+        table.insert(_ssh.console_command, ssh_config.proxyjump)
+        table.insert(_ssh._put_command, '-J')
+        table.insert(_ssh._put_command, ssh_config.proxyjump)
+        table.insert(_ssh._get_command, '-J')
+        table.insert(_ssh._get_command, ssh_config.proxyjump)
     end
 
     if utils.os ~= 'windows' then

--- a/lua/netman/providers/ssh.lua
+++ b/lua/netman/providers/ssh.lua
@@ -150,12 +150,12 @@ function SSH:new(auth_details, provider_cache)
         table.insert(_ssh._put_command, '-o')
         table.insert(_ssh._put_command, 'ControlMaster=auto')
 
-    table.insert(_ssh.console_command, '-o')
-    table.insert(_ssh.console_command,
+        table.insert(_ssh.console_command, '-o')
+        table.insert(_ssh.console_command,
         string.format('ControlPath="%s%s"', socket_files, SSH.CONSTANTS.SSH_SOCKET_FILE_NAME))
-    table.insert(_ssh._put_command, '-o')
-    table.insert(_ssh._put_command,
-        string.format('ControlPath="%s%s"', socket_files, SSH.CONSTANTS.SSH_SOCKET_FILE_NAME))
+        table.insert(_ssh._put_command, '-o')
+        table.insert(_ssh._put_command,
+            string.format('ControlPath="%s%s"', socket_files, SSH.CONSTANTS.SSH_SOCKET_FILE_NAME))
 
         table.insert(_ssh.console_command, '-o')
         table.insert(_ssh.console_command, string.format('ControlPersist=%s', SSH.CONSTANTS.SSH_CONNECTION_TIMEOUT))
@@ -1863,6 +1863,7 @@ function M.internal.validate(uri, cache)
     assert(cache, string.format("No cache provided for read of %s", uri))
     ---@diagnostic disable-next-line: cast-local-type
     uri = M.internal.URI:new(uri, cache)
+
     local host = M.internal.SSH:new(uri, cache)
     return { uri = uri, host = host }
 end


### PR DESCRIPTION
This adds support for reading the following values from the user's ssh configuration (note, there is not support for _other_ ssh configurations aside from the user ssh config)

- User
- Port
- IdentityFile
- ProxyJump
